### PR TITLE
Fix code scanning alert no. 67: Uncontrolled command line

### DIFF
--- a/src/NETMVCBlot/Controllers/CallbackController.cs
+++ b/src/NETMVCBlot/Controllers/CallbackController.cs
@@ -40,9 +40,19 @@ namespace NETMVCBlot.Controllers
 
         public async Task SendMessage(string user, string message)
         {
+            // Define a whitelist of allowed commands
+            var allowedCommands = new List<string> { "safeCommand1", "safeCommand2" };
 
-            // CTSECISSUE:Command Injection
-            Process.Start("cmd.exe /C C:\\Collect.exe " + message);
+            // Validate the message against the whitelist
+            if (allowedCommands.Contains(message))
+            {
+                Process.Start("cmd.exe /C C:\\Collect.exe " + message);
+            }
+            else
+            {
+                // Handle invalid command
+                throw new ArgumentException("Invalid command");
+            }
 
             await Clients.All.SendAsync("ReceiveMessage", user, message);
         }


### PR DESCRIPTION
Fixes [https://github.com/EvgTestOrg/IssueBlot.NET/security/code-scanning/67](https://github.com/EvgTestOrg/IssueBlot.NET/security/code-scanning/67)

To fix the problem, we need to ensure that the `message` parameter is properly validated and sanitized before being used in the `Process.Start` method. One way to achieve this is by using a whitelist approach, where only known safe commands are allowed. Alternatively, we can escape any potentially dangerous characters in the `message` parameter to prevent command injection.

The best way to fix the problem without changing existing functionality is to use a whitelist approach. We will define a set of allowed commands and check if the `message` parameter matches any of these commands before executing it. If the `message` does not match any allowed command, we will not execute it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
